### PR TITLE
Improve DrawTree readability.

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -428,13 +428,13 @@ func traverseTree(node *AstNodeT, wr io.Writer, depth int) error {
 
 	switch o := node.Object.(type) {
 	case *AstSeqMatcherT:
-		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Order), len(o.Negate), node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.ParentMatchId, o.Window, len(o.Order), len(o.Negate), node.Metadata.Scope)
 	case *AstSetMatcherT:
-		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.ParentMatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
 	case *AstLogMatcherT:
-		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.ParentMatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
 	case *AstDescriptorT:
-		obj = fmt.Sprintf("%s.%d.%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d.%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.ParentMatchId, node.Metadata.Scope)
 	default:
 		return fmt.Errorf("unknown object type: %T", o)
 	}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -3,7 +3,9 @@ package ast
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/prequel-dev/prequel-compiler/pkg/parser"
@@ -417,40 +419,34 @@ func BuildTree(tree *parser.TreeT) (*AstT, error) {
 	return ast, nil
 }
 
-func traverseTree(node *AstNodeT, f *os.File, indent string) error {
+func traverseTree(node *AstNodeT, wr io.Writer, depth int) error {
 
 	var (
-		parent string
-		child  string
-		err    error
+		obj string
+		err error
 	)
 
 	switch o := node.Object.(type) {
 	case *AstSeqMatcherT:
-		parent = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Order), len(o.Negate), node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Order), len(o.Negate), node.Metadata.Scope)
 	case *AstSetMatcherT:
-		parent = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
+		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
+	case *AstLogMatcherT:
+		obj = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), node.Metadata.Scope)
+	case *AstDescriptorT:
+		obj = fmt.Sprintf("%s.%d.%d scope=%s", node.Metadata.Type, node.Metadata.Depth, node.Metadata.MatchId, node.Metadata.Scope)
+	default:
+		return fmt.Errorf("unknown object type: %T", o)
 	}
 
-	if _, err = f.Write([]byte(fmt.Sprintf("%s%s\n", indent, parent))); err != nil {
+	indent := strings.Repeat("  ", depth)
+
+	if _, err = wr.Write([]byte(fmt.Sprintf("%d: %s%s\n", depth, indent, obj))); err != nil {
 		return err
 	}
 
-	indent += "  "
-
 	for _, c := range node.Children {
-		switch o := c.Object.(type) {
-		case *AstLogMatcherT:
-			child = fmt.Sprintf("%s.%d.%d w=%s pos_terms=%d neg_terms=%d scope=%s", c.Metadata.Type, c.Metadata.Depth, c.Metadata.MatchId, o.Window, len(o.Match), len(o.Negate), c.Metadata.Scope)
-		case *AstDescriptorT:
-			child = fmt.Sprintf("%s.%d.%d scope=%s", c.Metadata.Type, c.Metadata.Depth, c.Metadata.MatchId, c.Metadata.Scope)
-		}
-
-		if _, err = f.Write([]byte(fmt.Sprintf("%s%s\n", indent, child))); err != nil {
-			return err
-		}
-
-		if err = traverseTree(c, f, indent+"  "); err != nil {
+		if err = traverseTree(c, wr, depth+1); err != nil {
 			return err
 		}
 	}
@@ -469,7 +465,7 @@ func DrawTree(tree *AstT, path string) error {
 	}
 
 	for _, node := range tree.Nodes {
-		if err = traverseTree(node, f, ""); err != nil {
+		if err = traverseTree(node, f, 0); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Before:
```
machine_seq.0.0 w=30s pos_terms=2 neg_terms=1 scope=cluster
  log_seq.1.0 w=10s pos_terms=11 neg_terms=1 scope=node

  desc.1.0 scope=cluster

  desc.1.0 scope=cluster
    machine_seq.1.1 w=5s pos_terms=3 neg_terms=0 scope=cluster
      log_seq.2.0 w=1s pos_terms=2 neg_terms=0 scope=node

      desc.2.0 scope=cluster

      log_set.2.1 w=0s pos_terms=1 neg_terms=0 scope=node

      desc.2.1 scope=cluster

      log_set.2.2 w=0s pos_terms=1 neg_terms=0 scope=cluster

      desc.2.2 scope=cluster

  desc.1.1 scope=cluster

  log_set.1.2 w=0s pos_terms=1 neg_terms=0 scope=cluster

  desc.1.2 scope=cluster
```


After:

```
0: machine_seq.0.0 w=30s pos_terms=2 neg_terms=1 scope=cluster
1:   log_seq.1.0 w=10s pos_terms=11 neg_terms=1 scope=node
1:   desc.1.0 scope=cluster
1:   machine_seq.1.1 w=5s pos_terms=3 neg_terms=0 scope=cluster
2:     log_seq.2.0 w=1s pos_terms=2 neg_terms=0 scope=node
2:     desc.2.0 scope=cluster
2:     log_set.2.1 w=0s pos_terms=1 neg_terms=0 scope=node
2:     desc.2.1 scope=cluster
2:     log_set.2.2 w=0s pos_terms=1 neg_terms=0 scope=cluster
2:     desc.2.2 scope=cluster
1:   desc.1.1 scope=cluster
1:   log_set.1.2 w=0s pos_terms=1 neg_terms=0 scope=cluster
1:   desc.1.2 scope=cluster
0: desc.0.0 scope=cluster
```