### PR TITLE
Support extractions in compiler.

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -66,13 +66,17 @@ type AstNegateOptsT struct {
 	Absolute bool          `json:"absolute"`
 }
 
+type AstExtractT struct {
+	Name       string `json:"name"`
+	JqValue    string `json:"jq_value,omitempty"`
+	RegexValue string `json:"regex_value,omitempty"`
+}
+
 type AstFieldT struct {
 	Field      string          `json:"field"`
-	StrValue   string          `json:"str_value"`
-	JsonValue  string          `json:"json_value"`
-	RegexValue string          `json:"regex_value"`
 	TermValue  match.TermT     `json:"term_value"`
 	NegateOpts *AstNegateOptsT `json:"negate_opts"`
+	Extracts   []AstExtractT   `json:"extracts"`
 }
 
 type AstEventT struct {

--- a/pkg/ast/ast_test.go
+++ b/pkg/ast/ast_test.go
@@ -65,6 +65,10 @@ func TestAstSuccess(t *testing.T) {
 			rule:              testdata.TestSuccessNegateOptions2,
 			expectedNodeTypes: []string{"machine_seq", "log_seq", "log_set", "log_set"},
 		},
+		"Success_Extract1": {
+			rule:              testdata.TestSuccessSimpleExtraction,
+			expectedNodeTypes: []string{"machine_seq", "log_seq"},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -17,7 +17,7 @@ var (
 )
 
 var (
-	defaultPlugin  = &NodePlugin{}
+	defaultPlugin  = NewDefaultPlugin()
 	defaultRuntime = &NoopRuntime{}
 )
 
@@ -77,7 +77,7 @@ func WithPlugin(scope string, plugin PluginI) CompilerOptT {
 
 func parseOpts(opts []CompilerOptT) compilerOptsT {
 	o := compilerOptsT{
-		plugins: map[string]PluginI{"node": defaultPlugin},
+		plugins: map[string]PluginI{schema.ScopeDefault: defaultPlugin},
 		runtime: defaultRuntime,
 	}
 	for _, opt := range opts {

--- a/pkg/compiler/plugin.go
+++ b/pkg/compiler/plugin.go
@@ -6,13 +6,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type NodePlugin struct{}
+type DefaultPlugin struct{}
 
-func NewNodePlugin() *NodePlugin {
-	return &NodePlugin{}
+func NewDefaultPlugin() *DefaultPlugin {
+	return &DefaultPlugin{}
 }
 
-func (p *NodePlugin) Compile(runtime RuntimeI, node *ast.AstNodeT) (ObjsT, error) {
+func (p *DefaultPlugin) Compile(runtime RuntimeI, node *ast.AstNodeT) (ObjsT, error) {
 
 	var (
 		objs = make(ObjsT, 0)

--- a/pkg/parser/parse.go
+++ b/pkg/parser/parse.go
@@ -101,6 +101,7 @@ type ParseTermT struct {
 	Set        *ParseSetT        `yaml:"set,omitempty"`
 	Sequence   *ParseSequenceT   `yaml:"sequence,omitempty"`
 	NegateOpts *ParseNegateOptsT `yaml:",inline,omitempty"`
+	Extract    []ParseExtractT   `yaml:"extract,omitempty"`
 }
 
 type ParseSetT struct {
@@ -109,6 +110,12 @@ type ParseSetT struct {
 	Event        *ParseEventT `yaml:"event,omitempty"`
 	Match        []ParseTermT `yaml:"match,omitempty"`
 	Negate       []ParseTermT `yaml:"negate,omitempty"`
+}
+
+type ParseExtractT struct {
+	Name       string `yaml:"name"`
+	JqValue    string `yaml:"jq,omitempty"`
+	RegexValue string `yaml:"regex,omitempty"`
 }
 
 func (o *ParseTermT) UnmarshalYAML(unmarshal func(any) error) error {
@@ -126,6 +133,7 @@ func (o *ParseTermT) UnmarshalYAML(unmarshal func(any) error) error {
 		Set        *ParseSetT        `yaml:"set,omitempty"`
 		Sequence   *ParseSequenceT   `yaml:"sequence,omitempty"`
 		NegateOpts *ParseNegateOptsT `yaml:",inline,omitempty"`
+		Extract    []ParseExtractT   `yaml:"extract,omitempty"`
 	}
 	if err := unmarshal(&temp); err != nil {
 		return err
@@ -138,6 +146,7 @@ func (o *ParseTermT) UnmarshalYAML(unmarshal func(any) error) error {
 	o.Set = temp.Set
 	o.Sequence = temp.Sequence
 	o.NegateOpts = temp.NegateOpts
+	o.Extract = temp.Extract
 	return nil
 }
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -4,6 +4,7 @@ const (
 	ScopeOrganization = "organization"
 	ScopeCluster      = "cluster"
 	ScopeNode         = "node"
+	ScopeDefault      = "default"
 )
 
 type NodeTypeT string

--- a/pkg/testdata/rules.go
+++ b/pkg/testdata/rules.go
@@ -336,6 +336,32 @@ terms:
         - value: "Killing"
 `
 
+var TestSuccessSimpleExtraction = `
+rules:
+  - cre:
+      id: TestSuccessSimpleExtraction
+    metadata:
+      id: "J7uRQTGpGMyL1iFpssnBeS"
+      hash: "rdJLgqYgkEp8jg8Qks1qiq"
+      generation: 1
+    rule:
+      sequence:
+        window: 30s
+        event:
+          source: log
+        correlations:
+          - corr1
+        order:
+          - value: "term1"
+            extract:
+            - name: "corr1"
+              jq: ".field1"
+          - value: "term2"
+            extract:
+              - name: "corr1"
+                jq: ".field1"
+`
+
 /* Failure cases */
 var TestFailTypo = ` # Line 1 starts here
 rules:


### PR DESCRIPTION
- Replace node scope plugin with default.  Node scope plugin moved elsewhere.
- Support experimental field extraction and correlation feature in Prequel product.  This feature allows extraction of fields by either regex or jq which can be used to correlate matched terms. 

Example rule definition using extractions and a correlation:

```
rules:
  - cre:
      id: TestSuccessSimpleExtraction
    metadata:
      id: "J7uRQTGpGMyL1iFpssnBeS"
      hash: "rdJLgqYgkEp8jg8Qks1qiq"
      generation: 1
    rule:
      sequence:
        window: 30s
        event:
          source: log
        correlations:
          - corr1
        order:
          - value: "term1"
            extract:
            - name: "corr1"
              jq: ".field1"
          - value: "term2"
            extract:
              - name: "corr1"
                jq: ".field1"
```